### PR TITLE
Adding to 'show ip bgp' about RPKI validation status....

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6140,6 +6140,21 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
       if (CHECK_FLAG (binfo->flags, BGP_INFO_SELECTED))
 	vty_out (vty, ", best");
 
+      #ifdef HAVE_RPKI
+      vty_out(vty, ", RPKI validation status: ");
+      switch (binfo->rpki_validation_status) {
+        case RPKI_VALID:
+	  vty_out(vty, "valid");
+          break;
+        case RPKI_INVALID:
+	  vty_out(vty, "invalid");
+          break;
+        case RPKI_NOTFOUND:
+	  vty_out(vty, "not found");
+          break;
+      }
+      #endif
+
       vty_out (vty, "%s", VTY_NEWLINE);
 	  
       /* Line 4 display Community */
@@ -6187,6 +6202,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
 }  
 
 #define BGP_SHOW_SCODE_HEADER "Status codes: s suppressed, d damped, h history, * valid, > best, i - internal,%s              r RIB-failure, S Stale, R Removed%s"
+#define BGP_SHOW_RPKICODE_HEADER "RPKI codes: V valid, I invalid, N not found"
 #define BGP_SHOW_OCODE_HEADER "Origin codes: i - IGP, e - EGP, ? - incomplete%s%s"
 #define BGP_SHOW_HEADER "   Network          Next Hop            Metric LocPrf Weight Path%s"
 #define BGP_SHOW_DAMP_HEADER "   Network          From             Reuse    Path%s"
@@ -6390,6 +6406,10 @@ bgp_show_table (struct vty *vty, struct bgp_table *table, struct in_addr *router
 	      {
 		vty_out (vty, "BGP table version is 0, local router ID is %s%s", inet_ntoa (*router_id), VTY_NEWLINE);
 		vty_out (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+		#ifdef HAVE_RPKI
+		/* Provide RPKI Origin validation headers */
+		vty_out(vty, BGP_SHOW_RPKICODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+		#endif
 		vty_out (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
 		if (type == bgp_show_type_dampend_paths
 		    || type == bgp_show_type_damp_neighbor)
@@ -9921,6 +9941,10 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
     {
       vty_out (vty, "BGP table version is 0, local router ID is %s%s", inet_ntoa (bgp->router_id), VTY_NEWLINE);
       vty_out (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+      #ifdef HAVE_RPKI
+      /* Provide RPKI Origin validation headers */
+      vty_out(vty, BGP_SHOW_RPKICODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+      #endif
       vty_out (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
 
       vty_out (vty, "Originating default network 0.0.0.0%s%s",
@@ -9938,6 +9962,10 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
 		{
 		  vty_out (vty, "BGP table version is 0, local router ID is %s%s", inet_ntoa (bgp->router_id), VTY_NEWLINE);
 		  vty_out (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+		  #ifdef HAVE_RPKI
+		  /* Provide RPKI Origin validation headers */
+		  vty_out(vty, BGP_SHOW_RPKICODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+		  #endif
 		  vty_out (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
 		  header1 = 0;
 		}
@@ -9962,6 +9990,10 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
 		{
 		  vty_out (vty, "BGP table version is 0, local router ID is %s%s", inet_ntoa (bgp->router_id), VTY_NEWLINE);
 		  vty_out (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+		  #ifdef HAVE_RPKI
+		  /* Provide RPKI Origin validation headers */
+		  vty_out(vty, BGP_SHOW_RPKICODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+		  #endif
 		  vty_out (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
 		  header1 = 0;
 		}


### PR DESCRIPTION
While testing quagga BGPd with RPKI support, noticed some missing output for the validation status of each router in 'show ip bgp', and also missing the validation status in 'show ip bgp <route>', so I added a patch to show the status. It's been tested, but not throughly. 
