### PR TITLE
Build Quagga without SSH support of RTRlib

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -43,7 +43,9 @@
 #include "rtrlib/rtr_mgr.h"
 #include "rtrlib/lib/ip.h"
 #include "rtrlib/transport/tcp/tcp_transport.h"
+#if defined(FOUND_SSH)
 #include "rtrlib/transport/ssh/ssh_transport.h"
+#endif
 
 /**********************************/
 /** Declaration of variables     **/

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -39,7 +39,9 @@
 #include "rtrlib/rtr_mgr.h"
 #include "rtrlib/lib/ip.h"
 #include "rtrlib/transport/tcp/tcp_transport.h"
+#if defined(FOUND_SSH)
 #include "rtrlib/transport/ssh/ssh_transport.h"
+#endif
 
 /**********************************/
 /** Declaration of variables     **/

--- a/bgpd/bgp_rpki_commands.c
+++ b/bgpd/bgp_rpki_commands.c
@@ -34,7 +34,9 @@
 #include "rtrlib/rtrlib.h"
 #include "rtrlib/lib/ip.h"
 #include "rtrlib/transport/tcp/tcp_transport.h"
+#if defined(FOUND_SSH)
 #include "rtrlib/transport/ssh/ssh_transport.h"
+#endif
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_table.h"
@@ -120,6 +122,7 @@ delete_cache(void* value)
     }
   else
     {
+#if defined(FOUND_SSH)
       XFREE(MTYPE_BGP_RPKI_CACHE, cache_p->tr_config.ssh_config->host);
       XFREE(MTYPE_BGP_RPKI_CACHE, cache_p->tr_config.ssh_config->username);
       XFREE(MTYPE_BGP_RPKI_CACHE,
@@ -127,6 +130,7 @@ delete_cache(void* value)
       XFREE(MTYPE_BGP_RPKI_CACHE,
           cache_p->tr_config.ssh_config->server_hostkey_path);
       XFREE(MTYPE_BGP_RPKI_CACHE, cache_p->tr_config.ssh_config);
+#endif
     }
   XFREE(MTYPE_BGP_RPKI_CACHE, cache_p->rtr_socket->tr_socket);
   XFREE(MTYPE_BGP_RPKI_CACHE, cache_p->rtr_socket);
@@ -189,6 +193,7 @@ find_cache(struct list* cache_list, const char* host, const char* port_string,
         }
       else
         {
+#if defined(FOUND_SSH)
           if (strcmp(cache->tr_config.ssh_config->host, host) == 0)
             {
               if (port != 0)
@@ -200,6 +205,8 @@ find_cache(struct list* cache_list, const char* host, const char* port_string,
                 }
               return cache;
             }
+#endif
+	  break;
         }
     }
   return NULL ;
@@ -239,7 +246,7 @@ add_ssh_cache(struct list* cache_list, const char* host,
     const char* client_privkey_path, const char* client_pubkey_path,
     const char* server_pubkey_path)
 {
-
+#if defined(FOUND_SSH)
   struct tr_ssh_config* ssh_config_p;
   struct tr_socket* tr_socket_p;
   cache* cache_p;
@@ -280,6 +287,8 @@ add_ssh_cache(struct list* cache_list, const char* host,
   cache_p->type = SSH;
   listnode_add(cache_list, cache_p);
   return SUCCESS;
+#endif
+  return ERROR;
 }
 
 static void
@@ -403,12 +412,14 @@ rpki_config_write(struct vty * vty)
                 break;
 
               case SSH:
+#if defined(FOUND_SSH)
                 ssh_config = cache->tr_config.ssh_config;
                 vty_out(vty, "    rpki cache %s %u %s %s %s %s",
                     ssh_config->host, ssh_config->port, ssh_config->username,
                     ssh_config->client_privkey_path,
                     ssh_config->server_hostkey_path != NULL ?
                         ssh_config->server_hostkey_path : " ", VTY_NEWLINE);
+#endif
                 break;
 
               default:
@@ -634,20 +645,28 @@ DEFUN (rpki_cache,
     }
   // use ssh connection
   if (argc == 5)
-    {
+    {	    
+      // return_value is ERROR on default if
+      // there is no SSH support. Unexpected behavior!!!
+      return_value = ERROR;
+#if defined(FOUND_SSH)
       int port;
       VTY_GET_INTEGER("rpki cache ssh port", port, argv[1]);
       return_value = add_ssh_cache(
           currently_selected_cache_group->cache_config_list, argv[0], port,
           argv[2], argv[3], argv[4], NULL );
+#endif
     }
   else if (argc == 6)
     {
+      return_value = ERROR;
+#if defined(FOUND_SSH)
       unsigned int port;
       VTY_GET_INTEGER("rpki cache ssh port", port, argv[1]);
       return_value = add_ssh_cache(
           currently_selected_cache_group->cache_config_list, argv[0], port,
           argv[2], argv[3], argv[4], argv[5]);
+#endif
     }
   // use tcp connection
   else if (argc == 2)
@@ -831,9 +850,11 @@ DEFUN (show_rpki_cache_connection,
                     break;
 
                   case SSH:
+#if defined(FOUND_SSH)
                     ssh_config = cache->tr_config.ssh_config;
                     vty_out(vty, "  rpki cache %s %u %s", ssh_config->host,
                         ssh_config->port, VTY_NEWLINE);
+#endif
                     break;
 
                   default:

--- a/configure.ac
+++ b/configure.ac
@@ -1543,6 +1543,17 @@ if test "${enable_rpki}" = "yes"; then
 fi
 AM_CONDITIONAL([HAVE_RPKI], test "x$RPKI" = "xtrue")
 
+dnl ------------------------------------------
+dnl Check whether rtrlib was build with ssh support
+dnl ------------------------------------------
+AC_MSG_CHECKING([whether the RTR Library is compiled with SSH])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "rtrlib/rtrlib.h"]],
+  			[[struct tr_ssh_config config;]])],
+	[AC_MSG_RESULT(yes)
+	AC_DEFINE(FOUND_SSH,,found_ssh)],
+	AC_MSG_RESULT(no)
+)
+
 dnl ---------------------------
 dnl Check htonl works correctly
 dnl ---------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -1778,6 +1778,17 @@ if test "${enable_rpki}" = "yes"; then
 fi
 AM_CONDITIONAL([HAVE_RPKI], test "x$RPKI" = "xtrue")
 
+dnl ------------------------------------------
+dnl Check whether rtrlib was build with ssh support
+dnl ------------------------------------------
+AC_MSG_CHECKING([whether the RTR Library is compiled with SSH])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "rtrlib/rtrlib.h"]],
+  			[[struct tr_ssh_config config;]])],
+	[AC_MSG_RESULT(yes)
+	AC_DEFINE(FOUND_SSH,,found_ssh)],
+	AC_MSG_RESULT(no)
+)
+
 dnl ---------------------------
 dnl Check htonl works correctly
 dnl ---------------------------


### PR DESCRIPTION
If the RTRlib was compiled without SSH support, check certain blocks of code whether they
should be compiled or not. Even though it compiles without errors, this is experimental and most certainly causes unexpected behavior.
